### PR TITLE
Feature/manually verify first claim

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -47,12 +47,65 @@ DB.create_table? :claims do
   String :user_name
 end
 
+DB.create_table? :authorised_users do
+  Date :date_authorised
+  String :user_id
+  String :authorised_by_user_id
+  unique(:user_id)
+  primary_key [:user_id]
+end
+
 names = DB[:names].order(:name)
 keys  = DB[:keys].order(:names_name)
 claims = DB[:claims]
+authorised_users = DB[:authorised_users]
 
 @niceWords = ["swell", "cute", "nice", "adorable", "good-hearted", "lovely", "amazing", "awesome", "fantastic", "wonderful", "adorable", "ghostly", "pink", "purrfect", "supercalifragilisticexpialidocious", "thoughtful", "charming", "generous", "good", "helpful", "neat", "plucky", "sweet"]
 
+@users_requesting_validation = {}
+
+def handle_user_claiming_game(user, game)
+  t = Time.new
+  @date = t.strftime("%Y-%m-%d")
+  @user = user.name
+  @user_id = user.id
+
+  @num_of_claims = DB["select * FROM CLAIMS WHERE USER_ID IS \"#{@user_id}\" AND date_of_claim IS \"#{@date}\""]
+  @claims = @num_of_claims.count
+
+  if @claims >= @maxClaims
+    user.pm "You have already claimed more than #{@maxClaims} keys today. Please wait until tomorrow."
+    bot.send_message(@auditChannel, "<@#{@user_id}> were blocked from claiming a key. They've already reached #{@maxClaims} today.")
+
+    return 0
+  else
+    if keys.where(:names_name => game).empty?
+      user.pm "No unclaimed keys for game #{game} found."
+
+      return 0
+    end
+    result = keys.where(:names_name => game).first
+    key = result[:key]
+    donator = result[:user]
+    platform = result[:platform]
+
+    user.pm "Here is your #{platform} key for #{game}: #{key}."
+    user.pm "The key was donated by #{donator}. Remember to thank them!"
+
+    claims.insert(:date_of_claim => @date, :user_id => @user_id, :user_name => @user_name, :game => game, :key => key)
+
+    keys.where(:key => key).delete
+
+    @claims = @claims+1
+
+    bot.send_message(@auditChannel, "<@#{user.id}> claimed key #{key} for #{game}.")
+    bot.send_message(@auditChannel, "They have claimed #{@claims} keys today.")
+
+    @logger.info("Key #{key} for game #{game} was claimed by <@#{@user_id}>")
+  end
+
+  return 0
+end
 
 bot = Discordrb::Commands::CommandBot.new token: @token, client_id: @clientId, prefix: '!', advanced_functionality: true, chain_args_delim: ';'
 
@@ -86,7 +139,7 @@ bot.command(:list, description: "List all the games with keys in the database", 
 end
 
 bot.command(:add, min_args: 3, max_args: 3, description: "Add a game key.", usage: "!add  \"Game Name\" \"Game Key\" \"Platform (Steam/Origin/Etc)\".") do |_event, game, key, platform|
-  
+
   platform = platform.upcase
 
   @user = _event.user.name
@@ -101,7 +154,7 @@ bot.command(:add, min_args: 3, max_args: 3, description: "Add a game key.", usag
       @logger.info("Key #{@key} for game #{@game} was added by #{@user}")
       _event.user.pm "Added key #{@key} for game #{@game} to database."
       bot.send_message(@announcementChannel, "#{@user} added a key for #{@game}. They're so #{@niceWords.sample}!")
-    else 
+    else
       _event.user.pm "Key #{@key} already exists in database."
     end
   else
@@ -117,44 +170,55 @@ bot.command(:add, min_args: 3, max_args: 3, description: "Add a game key.", usag
   end
 end
 
-bot.command(:claim, min_args: 1, max_args: 1, description: "Claim a game key", usage: "!claim \"[game name]\". Note that the game contains spaces it must be whithin quotation marks!") do |event, game| 
-  t = Time.new
-  @date = t.strftime("%Y-%m-%d")
-  @user = event.user.name
+bot.command(:claim, min_args: 1, max_args: 1, description: "Claim a game key", usage: "!claim \"[game name]\". Note that the game contains spaces it must be within quotation marks!") do |event, game|
   @user_id = event.user.id
 
-  @num_of_claims = DB["select * FROM CLAIMS WHERE USER_ID IS \"#{@user_id}\" AND date_of_claim IS \"#{@date}\""]
-  @claims = @num_of_claims.count
-
-  if @claims >=  @maxClaims
-    event.user.pm "You have already claimed more than 3 keys today. Please wait until tomorrow."
-    bot.send_message(@auditChannel, "<@#{event.user.id}> were blocked from claiming a key. They've already reached #{@maxClaims} today.")
-    break
-  else
-    if keys.where(:names_name => game).empty?
-      event.user.pm "No unclaimed keys for game #{game} found."
-      break
-    end
-    result = keys.where(:names_name => game).first
-    key = result[:key]
-    user = result[:user]
-    platform = result[:platform]
-
-    event.user.pm "Here is your #{platform} key for #{game}: #{key}."
-    event.user.pm "The key was donated by #{user}. Remember to thank them!"
-
-    claims.insert(:date_of_claim => @date, :user_id => @user_id, :user_name => @user_name, :game => game, :key => key)
-
-    keys.where(:key => key).delete
-
-    @claims = @claims+1
-
-    bot.send_message(@auditChannel, "<@#{event.user.id}> claimed key #{key} for #{game}.")
-    bot.send_message(@auditChannel, "They have claimed #{@claims} keys today.")
-
-    @logger.info("Key #{key} for game #{game} was claimed by #{@user}")
-
+  if authorised_users.where(user_id: @user_id).empty?
+    event.user.pm "This is the first time you've tried to claim a key, so this request will be manually authorised by a moderator. Please be patient, we'll get to it as soon as possible."
+    bot.send_message(@auditChannel, "<@#{event.user.id}> has tried to claim a key for #{game} and is not authorised. Allow this with `!authorise #{event.user.id}`.")
+    @users_requesting_validation[@user_id: game]
     return 0
   end
+
+  return handle_user_claiming_game(event.user, game)
 end
+
+bot.command(
+  :authorise,
+  min_args: 1,
+  max_args: 1,
+  description: "Authorise a user to claim keys from the bot. If they requested a key already, that key will be immediately sent to them when confirmed.",
+  usage: "!authorise \"[discord user ID]\".",
+  help_available: false,
+  required_permissions: [:manage_server]
+) do |event, user_id_to_auth|
+  t = Time.new
+  @date = t.strftime("%Y-%m-%d")
+  @user_id = event.user.id
+
+  @authorised = DB["select * from validated_users where user_id is \"#{user_id_to_auth}\""].any?
+
+  if not authorised_users.where(user_id: user_id_to_auth).empty?
+    event << "This user with id #{user_id_to_auth} is already authorised!"
+    return 0
+  end
+
+  authorised_users.insert(date_authorised: @date, user_id: user_id_to_auth, authorised_by_user_id: @user_id)
+
+  if @users_requesting_validation[user_id_to_auth]
+    # Got to find the user object for the sake of PMing them
+    resolved_user = nil
+    bot.servers.each do |server|
+      resolved_user = server.member(user_id_to_auth)
+      if resolved_user then break
+    end
+    if resolved_user
+      handle_user_claiming_game(resolved_user, @users_requesting_validation[user_id_to_auth])
+    end
+    @users_requesting_validation.delete(user_id_to_auth)
+  end
+
+  return 0
+end
+
 bot.run

--- a/main.rb
+++ b/main.rb
@@ -187,10 +187,11 @@ bot.command(
   :authorise,
   min_args: 1,
   max_args: 1,
-  description: "Authorise a user to claim keys from the bot. If they requested a key already, that key will be immediately sent to them when confirmed.",
+  description: "Authorise a user to claim keys from the bot. If they requested a key already, that key will be immediately sent to them when confirmed. Only works in the audit channel.",
   usage: "!authorise \"[discord user ID]\".",
   help_available: false,
-  required_permissions: [:manage_server]
+  required_permissions: [:manage_server],
+  channels: [@auditChannel]
 ) do |event, user_id_to_auth|
   t = Time.new
   @date = t.strftime("%Y-%m-%d")


### PR DESCRIPTION
Make it so the first time a user tries to get a key, they are instead asked to wait and the audit channel is alerted to the request.

Users can be authorised with "!authorise <user id>" in the audit channel ONLY, by users with the "Manage server" permission ONLY.

Once the user has been auth'd the server will then treat any further key requests as we currently do, with the daily limit and whatnot.

In theory I've refactored to reuse the key request code so that users who request a game and get auth'd should immediately resolve the game request as normal, but the list of requests is only kept in memory so no guarantees or anything. Not a big deal.